### PR TITLE
Orebfuscator for CraftBukkit/Spigot 1.8.8 with ViaVersion 1.0.4 and ProtocolLib 4.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.lishid</groupId>
   <artifactId>orebfuscator</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.6</version>
+  <version>3.0.6i</version>
   <name>Orebfuscator</name>
   <url>http://dev.bukkit.org/server-mods/orebfuscator/</url>
 
@@ -14,12 +14,12 @@
 
   <repositories>
     <repository>
-      <id>comphenix-snapshots</id>
-      <url>http://repo.comphenix.net/content/repositories/snapshots/</url>
+      <id>dmulloy2-repo</id>
+      <url>http://repo.dmulloy2.net/content/groups/public/</url>
     </repository>
     <repository>
-      <id>repobo-snap</id>
-      <url>http://repo.bukkit.org/content/groups/public</url>
+      <id>spigot-repo</id>
+      <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
     </repository>
   </repositories>
 
@@ -34,14 +34,13 @@
     <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>craftbukkit</artifactId>
-      <version>1.8.4-R0.1-SNAPSHOT</version>
-      <scope>system</scope>
-      <systemPath>U:/Downloads/spigot-1.8.4-R0.1-SNAPSHOT-latest.jar</systemPath>
+      <version>1.8.6-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.comphenix.protocol</groupId>
-      <artifactId>ProtocolLib</artifactId>
-      <version>3.5.0-SNAPSHOT</version>
+      <artifactId>ProtocolLib-API</artifactId>
+      <version>4.2.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -49,6 +48,7 @@
   <build>
     <defaultGoal>clean install</defaultGoal>
     <sourceDirectory>src/main/java</sourceDirectory>
+    <testSourceDirectory>src/test/java</testSourceDirectory>
     <resources>
       <resource>
         <directory>src/main/resources</directory>

--- a/src/main/java/com/lishid/orebfuscator/OrebfuscatorConfig.java
+++ b/src/main/java/com/lishid/orebfuscator/OrebfuscatorConfig.java
@@ -121,7 +121,10 @@ public class OrebfuscatorConfig {
             if (i == org.bukkit.Material.TNT.getId()) {
                 TransparentBlocks[i] = false;
             }
-            if (i == org.bukkit.Material.AIR.getId()) {
+            if (i == org.bukkit.Material.AIR.getId() ||
+                i == org.bukkit.Material.WATER.getId() ||
+                i == org.bukkit.Material.STATIONARY_WATER.getId() ||
+                i == org.bukkit.Material.WEB.getId()) {
                 TransparentBlocks[i] = true;
             }
         }

--- a/src/main/java/com/lishid/orebfuscator/hook/ProtocolLibHook.java
+++ b/src/main/java/com/lishid/orebfuscator/hook/ProtocolLibHook.java
@@ -23,6 +23,7 @@ import com.comphenix.protocol.ProtocolManager;
 import com.comphenix.protocol.events.ConnectionSide;
 import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.EnumWrappers;
 import com.lishid.orebfuscator.hithack.BlockHitManager;
 import com.lishid.orebfuscator.internal.Packet51;
 import com.lishid.orebfuscator.obfuscation.Calculations;
@@ -46,16 +47,13 @@ public class ProtocolLibHook {
             }
         });
 
-        Integer[] packets2 = new Integer[]{Packets.Client.BLOCK_DIG};
-        manager.addPacketListener(new PacketAdapter(plugin, ConnectionSide.CLIENT_SIDE, packets2) {
+        manager.addPacketListener(new PacketAdapter(plugin, PacketType.Play.Client.BLOCK_DIG) {
             @Override
             public void onPacketReceiving(PacketEvent event) {
-                if (event.getPacketID() == Packets.Client.BLOCK_DIG) {
-                    EnumPlayerDigType status = event.getPacket().getSpecificModifier(EnumPlayerDigType.class).read(0);
-                    if (status == EnumPlayerDigType.ABORT_DESTROY_BLOCK) {
-                        if (!BlockHitManager.hitBlock(event.getPlayer(), null)) {
-                            event.setCancelled(true);
-                        }
+                EnumWrappers.PlayerDigType status = event.getPacket().getPlayerDigTypes().read(0);
+                if (status == EnumWrappers.PlayerDigType.ABORT_DESTROY_BLOCK) {
+                    if (!BlockHitManager.hitBlock(event.getPlayer(), null)) {
+                        event.setCancelled(true);
                     }
                 }
             }

--- a/src/main/java/com/lishid/orebfuscator/internal/MinecraftInternals.java
+++ b/src/main/java/com/lishid/orebfuscator/internal/MinecraftInternals.java
@@ -27,7 +27,7 @@ import org.bukkit.entity.Player;
 
 public class MinecraftInternals {
     public static boolean isBlockTransparent(int id) {
-        return Block.getById(id).u();
+        return Block.getById(id).s();
     }
 
     public static void updateBlockTileEntity(org.bukkit.block.Block block, Player player) {

--- a/src/main/java/com/lishid/orebfuscator/obfuscation/Calculations.java
+++ b/src/main/java/com/lishid/orebfuscator/obfuscation/Calculations.java
@@ -100,7 +100,6 @@ public class Calculations {
         if (info.chunkMask == 0) {
             return;
         }
-
         ComputeChunkInfoAndObfuscate(info);
     }
 
@@ -152,20 +151,18 @@ public class Calculations {
 
         // Caching
         if (OrebfuscatorConfig.UseCache) {
+            // Hash the chunk
+            hash = CalculationsUtil.Hash(info.buffer, info.bytes);
             // Sanitize buffer for caching
             PrepareBufferForCaching(info.buffer, info.bytes);
-
             // Get cache folder
             File cacheFolder = new File(OrebfuscatorConfig.getCacheFolder(), info.world.getName());
             // Create cache objects
             cache = new ObfuscatedCachedChunk(cacheFolder, info.chunkX, info.chunkZ);
-            info.useCache = true;
-            // Hash the chunk
-            hash = CalculationsUtil.Hash(info.buffer, info.bytes);
-
+            info.useCache = true;                     
             // Check if hash is consistent
             cache.Read();
-
+            
             long storedHash = cache.getHash();
             int[] proximityList = cache.proximityList;
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: Orebfuscator3
 main: com.lishid.orebfuscator.Orebfuscator
-version: 3.0.6
+version: 3.0.6i
 author: lishid
 softdepend: [ProtocolLib]
 load: startup


### PR DESCRIPTION
Changes to Orebfuscator involve transparent blocks, caching, and the interface to ProtocolLib.  Changes come from MarioG1, Likaos, Aleksey-Terzi, and lbjdaking23.